### PR TITLE
Invoke error callback if permissions are not granted on android

### DIFF
--- a/android/src/main/java/com/wenkesj/voice/VoiceModule.java
+++ b/android/src/main/java/com/wenkesj/voice/VoiceModule.java
@@ -146,6 +146,10 @@ public class VoiceModule extends ReactContextBaseJavaModule implements Recogniti
               permissionsGranted = permissionsGranted && granted;
             }
 
+            if (!permissionsGranted) {
+              callback.invoke(SpeechRecognizer.ERROR_INSUFFICIENT_PERMISSIONS + "/ERROR_INSUFFICIENT_PERMISSIONS");
+            }
+
             return permissionsGranted;
           }
         });


### PR DESCRIPTION
Right now, if the user clicks on the deny button, we do not know about it. Also, if they've chosen to never ask for it again, we wouldn't know about it at all. With this, it'll throw an exception and we can catch and examine the error to handle it gracefully.