### PR TITLE
Generate APK 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,26 +1,11 @@
 apply plugin: 'com.android.library'
 
-repositories {
-    mavenLocal()
-    jcenter()
-    maven {
-        // For developing the library outside the context of the example app, expect `react-native`
-        // to be installed at `./node_modules`.
-        url "$projectDir/../node_modules/react-native/android"
-    }
-    maven {
-        // For developing the example app.
-        url "$projectDir/../../react-native/android"
-    }
-}
-
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 23
+        minSdkVersion 16
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }
@@ -35,9 +20,10 @@ android {
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:3.3.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -47,12 +33,13 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.1.1'
-    compile 'com.facebook.react:react-native:+'
+   implementation fileTree(dir: 'libs', include: ['*.jar'])
+    // testCompile 'junit:junit:4.12'
+   implementation 'com.android.support:appcompat-v7:28.0.0'
+   implementation 'com.facebook.react:react-native:+'
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip


### PR DESCRIPTION
When configuring Issue #17287 https://github.com/facebook/react-native/issues/17287, when generating any apk with new react-native versions, it presented the following error: Task: react -native-voice: verifyReleaseResources FAILED. The correction can be made by updating the files gradle-wrapper.properties and build.gradle, as updated in this branch.



