### PR TITLE
fix(iOS): prevent crash with headset/bluetooth

### DIFF
--- a/ios/Voice/Voice.m
+++ b/ios/Voice/Voice.m
@@ -224,7 +224,7 @@
         [mixer installTapOnBus:0 bufferSize:1024 format:recordingFormat block:^(AVAudioPCMBuffer * _Nonnull buffer, AVAudioTime * _Nonnull when) {
             //Volume Level Metering
             //Buffer frame can be reduced, if you need more output values
-            [buffer setFrameLength:4096];
+            [buffer setFrameLength: buffer.frameCapacity];
             UInt32 inNumberFrames = buffer.frameLength;
             float LEVEL_LOWPASS_TRIG = 0.5;
             if(buffer.format.channelCount>0)


### PR DESCRIPTION
- Error "required condition is false : length <= _imp->_frameCapacity"
- Issue #275