### PR TITLE
fix(Android) Support Android target >= 11

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -5,4 +5,10 @@
     <uses-sdk tools:overrideLibrary="com.facebook.react" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.INTERNET" />
+
+    <queries>
+        <intent>
+            <action android:name="android.speech.RecognitionService"/>
+        </intent>
+    </queries>
 </manifest>


### PR DESCRIPTION
The android apps targeting >= 30 (>= Android 11), needs to add a query for information about the other apps that are installed on a device, in this particular case for the Voice Recognition we need to add the RecognitionService into a query 

More info here... https://developer.android.com/about/versions/11/privacy/package-visibility

So if you add it in the manifest.xml here in the library, the implementing users won't need to add in their manifest and you avoid an extra step to configure this library.

