### PR TITLE
fix (iOS): unsupported locale

### DIFF
--- a/ios/Voice/Voice.m
+++ b/ios/Voice/Voice.m
@@ -288,6 +288,13 @@
     self.speechRecognizer = [[SFSpeechRecognizer alloc] init];
   }
 
+  if (self.speechRecognizer == nil) {
+      NSString *errorMessage = [NSString stringWithFormat: @"recognition is not supported for locale %@", localeStr];
+      [self sendResult:@{@"code": @"recognition_fail", @"message": errorMessage} :nil :nil :nil];
+      [self teardown];
+      return;
+    }
+
   self.speechRecognizer.delegate = self;
 
   // Start audio session...


### PR DESCRIPTION
Hello, I found this repository useful for one of my client project. In the app I’m developing (iOS), user can swipe between languages (let’s say English [en-IN] - Gujarati [gu-IN]) and start voice recognition. Currently `SFSpeechRecognizer` supports limited `locale`. `initWithLocale` would return `nil`; when, we try to initialise speech recogniser object with such an unsupported locale.
https://developer.apple.com/documentation/speech/sfspeechrecognizer/1649877-initwithlocale#return_value

Kindly review and provide feedback.