### PR TITLE
fix: new NativeEventEmitter() was called with a non-null argument console warning

### DIFF
--- a/android/src/main/java/com/wenkesj/voice/VoiceModule.java
+++ b/android/src/main/java/com/wenkesj/voice/VoiceModule.java
@@ -401,4 +401,14 @@ public class VoiceModule extends ReactContextBaseJavaModule implements Recogniti
     }
     return message;
   }
+
+  @ReactMethod
+  public void addListener(String eventName) {
+
+  }
+
+  @ReactMethod
+  public void removeListeners(Integer count) {
+
+  }
 }


### PR DESCRIPTION
Add `addListener` and `removeListeners` method to stop console warning about:
```
WARN new NativeEventEmitter() was called with a non-null argument without the required addListener method.
WARN new NativeEventEmitter() was called with a non-null argument without the required removeListeners method.
```

Issue #455 

[reference](https://stackoverflow.com/a/72516352)