### PR TITLE
Replace deprecated jcenter() with mavenCentral()

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 repositories {
     mavenLocal()
-    jcenter()
+    mavenCentral()
     maven {
         // For developing the library outside the context of the example app, expect `react-native`
         // to be installed at `./node_modules`.
@@ -40,7 +40,7 @@ android {
 buildscript {
     if (project == rootProject) {
         repositories {
-            jcenter()
+            mavenCentral()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:3.3.2'
@@ -53,7 +53,7 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath("com.android.tools.build:gradle:3.4.2")
@@ -32,7 +32,7 @@ allprojects {
         }
 
         google()
-        jcenter()
+        mavenCentral()
         maven { url 'https://jitpack.io' }
     }
 }


### PR DESCRIPTION
This PR addresses the deprecation warning of the jcenter() method in the build.gradle file of the react-native-community/voice package.

JCenter has been sunsetted and is read-only now. Gradle has also deprecated the jcenter() method and it is scheduled to be removed in Gradle 9.0. To resolve this, I have replaced jcenter() with mavenCentral().

This change will help maintain the longevity and reliability of the package by ensuring it doesn't rely on a deprecated and read-only repository.

Please let me know if there are any issues or further changes needed.