### PR TITLE
add null check to onResult callback

### DIFF
--- a/android/src/main/java/com/wenkesj/voice/VoiceModule.java
+++ b/android/src/main/java/com/wenkesj/voice/VoiceModule.java
@@ -344,6 +344,10 @@ public class VoiceModule extends ReactContextBaseJavaModule implements Recogniti
 
   @Override
   public void onResults(Bundle results) {
+    // check if results is null or undefined
+    if (results == null || results.isEmpty()) {
+      return;
+    }
     WritableArray arr = Arguments.createArray();
 
     ArrayList<String> matches = results.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION);


### PR DESCRIPTION
PR to fix android crashing on result being null:

 E  FATAL EXCEPTION: main
                                                                                                    Process: com.poc_speech_recognigtion, PID: 11881
                                                                                                    java.lang.NullPointerException: Attempt to invoke virtual method 'java.util.Iterator java.util.ArrayList.iterator()' on a null object reference
                                                                                                    	at com.wenkesj.voice.VoiceModule.onResults(VoiceModule.java:354)
                                                                                                    	at android.speech.SpeechRecognizer$InternalRecognitionListener$1.handleMessage(SpeechRecognizer.java:1062)
                                                                                                    	at android.os.Handler.dispatchMessage(Handler.java:106)
                                                                                                    	at android.os.Looper.loopOnce(Looper.java:230)
                                                                                                    	at android.os.Looper.loop(Looper.java:319)
                                                                                                    	at android.app.ActivityThread.main(ActivityThread.java:8893)
                                                                                                    	at java.lang.reflect.Method.invoke(Native Method)
                                                                                                    	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:608)
                                                                                                    	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1103)
