### PR TITLE
fix(android): update path of newarch generated classes

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -92,8 +92,8 @@ android {
         java.srcDirs += [
           "src/newarch",
           // Codegen specs
-          "generated/java",
-          "generated/jni"
+          "${project.buildDir}/generated/source/codegen/java",
+          "${project.buildDir}/generated/source/codegen/jni"
         ]
       } else {
         java.srcDirs += ["src/oldarch"]

--- a/package.json
+++ b/package.json
@@ -62,11 +62,10 @@
   },
   "codegenConfig": {
     "name": "RNVoiceSpec",
-    "type": "all",
+    "type": "modules",
     "jsSrcsDir": "src",
     "outputDir": {
-      "ios": "ios/generated",
-      "android": "android/generated"
+      "ios": "ios/generated"
     },
     "android": {
       "javaPackageName": "com.wenkesj.voice"


### PR DESCRIPTION
The path generation in Android assuming developer always run this command to generate source code during prebuild:
```
./gradlew generateCodegenArtifactsFromSchema
```

However, for my project, the outputDir in codegenConfig is not respect correctly. This happens probably due to gradle or AGP version. When I change to project.buildDir absolute path, the Android build is working for new architecture.