### PR TITLE
fix(android): update build.gradle for RN 0.74+ compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,19 +1,3 @@
-buildscript {
-  // Buildscript is evaluated before everything else so we can't use getExtOrDefault
-  def kotlin_version = rootProject.ext.has("kotlinVersion") ? rootProject.ext.get("kotlinVersion") : project.properties["Voice_kotlinVersion"]
-
-  repositories {
-    google()
-    mavenCentral()
-  }
-
-  dependencies {
-    classpath "com.android.tools.build:gradle:7.2.1"
-    // noinspection DifferentKotlinGradleVersion
-    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-  }
-}
-
 def reactNativeArchitectures() {
   def value = rootProject.getProperties().get("reactNativeArchitectures")
   return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
@@ -43,7 +27,6 @@ def supportsNamespace() {
   def major = parsed[0].toInteger()
   def minor = parsed[1].toInteger()
 
-  // Namespace support was added in 7.3.0
   return (major == 7 && minor >= 3) || major >= 8
 }
 
@@ -91,13 +74,28 @@ android {
       if (isNewArchitectureEnabled()) {
         java.srcDirs += [
           "src/newarch",
-          // Codegen specs
           "generated/java",
           "generated/jni"
         ]
       } else {
         java.srcDirs += ["src/oldarch"]
       }
+    }
+  }
+
+  packaging {
+    resources {
+      excludes += [
+        "META-INF/DEPENDENCIES",
+        "META-INF/LICENSE",
+        "META-INF/LICENSE.txt",
+        "META-INF/license.txt",
+        "META-INF/NOTICE",
+        "META-INF/NOTICE.txt",
+        "META-INF/notice.txt",
+        "META-INF/ASL2.0",
+        "META-INF/*.kotlin_module"
+      ]
     }
   }
 }
@@ -110,9 +108,6 @@ repositories {
 def kotlin_version = getExtOrDefault("kotlinVersion")
 
 dependencies {
-  // For < 0.71, this will be from the local maven repo
-  // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
-  //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }


### PR DESCRIPTION
This PR updates `android/build.gradle` to resolve common build issues in modern React Native versions (0.74+):

- Removes the outdated `buildscript` block, which forces downloading AGP 7.2.1 (causing TLS handshake failures via proxies/VPNs). Now inherits the root project's modern AGP (8.x+).
- Adds `packaging` options to fix resource merging errors in Gradle 8+ (e.g., duplicate META-INF files).

Tested on RN 0.75: Builds cleanly without patches.

Please consider publishing a new npm version after merge (last release was v3.2.4 in 2022—many users install from GitHub master due to outdated npm).