### PR TITLE
fix(ci): properly fail release job when npm publish fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
       - rn/yarn_install
       - run:
           name: Publish to NPM
-          command: yarn semantic-release || true
+          command: yarn semantic-release
 
 workflows:
   ci:


### PR DESCRIPTION
## Problem

The release job was configured with `|| true` which caused it to always succeed, even when npm publishing failed. This made it confusing to determine the actual status of releases.

## Solution

Remove `|| true` from the semantic-release command so that publishing failures are properly reported.

## Changes

- `.circleci/config.yml`: Remove error suppression from release command