### PR TITLE
Android: Fix RN 0.83+ New Architecture compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,9 @@ def reactNativeArchitectures() {
 }
 
 def isNewArchitectureEnabled() {
-  return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
+  // We treat New Architecture as enabled by default (RN 0.82+).
+  // If a project explicitly sets newArchEnabled, we respect it.
+  return !rootProject.hasProperty("newArchEnabled") || rootProject.getProperty("newArchEnabled") == "true"
 }
 
 apply plugin: "com.android.library"
@@ -100,15 +102,11 @@ android {
   }
 }
 
-repositories {
-  mavenCentral()
-  google()
-}
 
 def kotlin_version = getExtOrDefault("kotlinVersion")
 
 dependencies {
-  implementation "com.facebook.react:react-native:+"
+  implementation("com.facebook.react:react-android")
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 

--- a/android/src/main/java/com/wenkesj/voice/Voice.kt
+++ b/android/src/main/java/com/wenkesj/voice/Voice.kt
@@ -136,7 +136,9 @@ class Voice (context:ReactApplicationContext):RecognitionListener {
   }
 
   fun startSpeech(locale: String?, opts: ReadableMap, callback: Callback?) {
-    if (!isPermissionGranted() && opts.getBoolean("REQUEST_PERMISSIONS_AUTO")) {
+    if (!isPermissionGranted()
+      && opts.hasKey("REQUEST_PERMISSIONS_AUTO")
+      && opts.getBoolean("REQUEST_PERMISSIONS_AUTO")) {
       val PERMISSIONS = arrayOf<String>(Manifest.permission.RECORD_AUDIO)
       if (reactContext.currentActivity != null) {
         (reactContext.currentActivity as PermissionAwareActivity).requestPermissions(
@@ -147,7 +149,12 @@ class Voice (context:ReactApplicationContext):RecognitionListener {
             val granted = grantResults[i] == PackageManager.PERMISSION_GRANTED
             permissionsGranted = permissionsGranted && granted
           }
-          startSpeechWithPermissions(locale!!, opts, callback!!)
+          if (permissionsGranted) {
+            startSpeechWithPermissions(locale!!, opts, callback!!)
+          } else {
+            // We only start recognition when permission is granted.
+            callback?.invoke("Insufficient permissions")
+          }
           permissionsGranted
         }
       }


### PR DESCRIPTION
Fixes Android on RN 0.83+ (new arch): treat new architecture as enabled by default when newArchEnabled is unset, remove module-level repositories block for modern Gradle setups, switch dependency to react-android, and only start recognition after RECORD_AUDIO permission is granted.